### PR TITLE
Add NOx and proxy emissions dashboard visuals

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1,153 +1,411 @@
 // ---------- Config you can tweak ----------
-const CI_SCALE_G_PER_KWH = 350;   // multiply your carbonperproduction index by this to get gCO2/kWh
-const ETS_PRICE_EUR_PER_T = 85;   // €/tCO2, adjust to current price
-const CO2_TARGET_TPD = 12.0;      // example target for the bar chart
+const DEFAULT_NOX_LIMIT = 70; // mg/Nm³
+const HOURS_PER_MONTH = 24 * 30; // treat every 720 hours as a "month"
 
-// ---------- Tabs behavior ----------
+// ---------- Tabs behaviour ----------
 document.addEventListener("DOMContentLoaded", () => {
   const btns = document.querySelectorAll(".tab-btn");
   const panels = {
-    emissions: document.getElementById("tab-emissions"),
-    performance: document.getElementById("tab-performance")
+    nox: document.getElementById("tab-nox"),
+    proxy: document.getElementById("tab-proxy")
   };
-  btns.forEach(b => {
-    b.id = `tabbtn-${b.dataset.tab}`;
-    b.addEventListener("click", () => {
-      btns.forEach(x => x.classList.remove("active"));
-      b.classList.add("active");
-      Object.values(panels).forEach(p => p.classList.remove("show"));
-      panels[b.dataset.tab].classList.add("show");
-      panels[b.dataset.tab].scrollIntoView({ behavior: "smooth", block: "start" });
+
+  btns.forEach((btn) => {
+    btn.id = `tabbtn-${btn.dataset.tab}`;
+    btn.addEventListener("click", () => {
+      btns.forEach((b) => b.classList.remove("active"));
+      btn.classList.add("active");
+      Object.values(panels).forEach((panel) => panel.classList.remove("show"));
+      panels[btn.dataset.tab].classList.add("show");
+      panels[btn.dataset.tab].scrollIntoView({ behavior: "smooth", block: "start" });
     });
   });
 
-  // kick off data load
   initDashboard();
 });
 
-// ---------- Helpers ----------
-async function fetchSeries(path) {
-  const r = await fetch(path);
-  const txt = await r.text();
-  return txt.split(/\r?\n/).map(s => s.trim()).filter(Boolean).map(Number);
-}
-function rollingNoise(base, n, jitter) {
-  // quick placeholder generator for NOx and CO, until backend provides real series
-  const out = [];
-  let v = base;
-  for (let i = 0; i < n; i++) {
-    v += (Math.random() - 0.5) * jitter;
-    out.push(Math.max(0, v));
-  }
-  return out;
-}
-function labelsFromLength(n) {
-  // simple 1..n labels, or replace with timestamps later
-  return Array.from({ length: n }, (_, i) => `${i + 1}`);
-}
+// ---------- State ----------
+let rawData = [];
+let chartNoxMonthly, chartProxyMonthly;
 
-// ---------- Charts ----------
-let chartEmissions, chartCO2Bar, chartEfficiency, chartCI;
-
+// ---------- Data loading & preparation ----------
 async function initDashboard() {
-  // Load your files from /static/data
-  const co2_tpd = await fetchSeries("/static/data/carbonperdaywith600mw.txt");      // tonnes per day
-  const eff_pct = await fetchSeries("/static/data/efficiencies.txt");               // percent
-  const ci_index = await fetchSeries("/static/data/carbonperproduction.txt");       // index around 1.0
-
-  // Derive other series
-  const n = Math.max(co2_tpd.length, eff_pct.length, ci_index.length);
-  const labels = labelsFromLength(n);
-
-  const nox_ppm = rollingNoise(150, n, 6);   // placeholder
-  const co_ppm  = rollingNoise(30,  n, 3);   // placeholder
-
-  // Scale carbon intensity to gCO2/kWh
-  const ci_g_per_kwh = ci_index.map(x => +(x * CI_SCALE_G_PER_KWH).toFixed(0));
-
-  // ETS exposure, simple product of CO2 and price
-  const ets_eur = co2_tpd.map(v => +(v * ETS_PRICE_EUR_PER_T).toFixed(0));
-
-  // Fill KPI cards with latest values
-  const last = (arr) => arr[arr.length - 1];
-  setText("kpi-nox", last(nox_ppm).toFixed(0));
-  setText("kpi-co",  last(co_ppm).toFixed(0));
-  setText("kpi-co2", last(co2_tpd).toFixed(2));
-  setText("kpi-eff", last(eff_pct).toFixed(2));
-  setText("kpi-ci",  last(ci_g_per_kwh).toFixed(0));
-  setText("kpi-ets", last(ets_eur).toFixed(0));
-
-  // Simple status chips
-  setChips("emissions-alerts", [
-    last(nox_ppm) > 180 ? "Warning, NOx high" : null,
-    last(co_ppm)  > 50  ? "Warning, CO high"  : null,
-    last(co2_tpd) > CO2_TARGET_TPD ? "CO₂ above target" : null
-  ]);
-  setChips("perf-alerts", [
-    last(eff_pct) < 42 ? "Efficiency below desired" : null,
-    last(ci_g_per_kwh) > 380 ? "Carbon intensity above target" : null
-  ]);
-
-  // Build charts
-  const ctxEmis   = document.getElementById("chartEmissions");
-  const ctxCO2Bar = document.getElementById("chartCO2Bar");
-  const ctxEff    = document.getElementById("chartEfficiency");
-  const ctxCI     = document.getElementById("chartCI");
-
-  chartEmissions = new Chart(ctxEmis, {
-    type: "line",
-    data: {
-      labels,
-      datasets: [
-        { label: "NOx ppm", data: nox_ppm, tension: 0.25, pointRadius: 0 },
-        { label: "CO ppm", data: co_ppm, tension: 0.25, pointRadius: 0 },
-        { label: "CO₂ tpd", data: co2_tpd, tension: 0.25, pointRadius: 0, yAxisID: "y2" }
-      ]
-    },
-    options: {
-      responsive: true, maintainAspectRatio: false,
-      scales: {
-        y:  { position: "left"  },
-        y2: { position: "right", grid: { drawOnChartArea: false } }
-      },
-      plugins: { legend: { display: true } }
+  rawData = await loadGTData("/static/data/gt_full.csv");
+  const limitInput = document.getElementById("nox-limit");
+  limitInput.value = DEFAULT_NOX_LIMIT;
+  limitInput.addEventListener("change", () => {
+    const current = Number(limitInput.value);
+    if (!Number.isFinite(current) || current <= 0) {
+      limitInput.value = DEFAULT_NOX_LIMIT;
     }
+    renderAll(Number(limitInput.value));
   });
 
-  chartCO2Bar = new Chart(ctxCO2Bar, {
-    type: "bar",
-    data: {
-      labels: ["Target", "Latest"],
-      datasets: [{ label: "CO₂ tpd", data: [CO2_TARGET_TPD, last(co2_tpd)] }]
-    },
-    options: { responsive: true, maintainAspectRatio: false, plugins: { legend: { display: false } } }
+  renderAll(DEFAULT_NOX_LIMIT);
+}
+
+async function loadGTData(path) {
+  const resp = await fetch(path);
+  const text = await resp.text();
+  const lines = text.trim().split(/\r?\n/).filter(Boolean);
+  const headers = lines[0].split(",").map(stripQuotes);
+  return lines.slice(1).map((line) => {
+    const values = line.split(",").map(stripQuotes);
+    const row = {};
+    headers.forEach((h, idx) => {
+      if (!h) return;
+      row[h] = Number(values[idx]);
+    });
+    return row;
+  });
+}
+
+function stripQuotes(value) {
+  return value.replace(/^"|"$/g, "");
+}
+
+function renderAll(limit) {
+  const summaries = computeSummaries(rawData, limit);
+  updateNoxKpis(summaries.overall);
+  updateProxyKpis(summaries.proxyOverall);
+  renderMonthlyNoxChart(summaries.monthly, limit);
+  renderProxyChart(summaries.monthly);
+  fillMonthlyTable(summaries.monthly);
+  fillLoadBinTable(summaries.loadBins);
+}
+
+function computeSummaries(rows, limit) {
+  const monthly = [];
+  const loadValues = [];
+  const noxValues = [];
+  const ratioNox = [];
+  const ratioCo = [];
+
+  rows.forEach((row, idx) => {
+    const monthIdx = Math.floor(idx / HOURS_PER_MONTH);
+    if (!monthly[monthIdx]) {
+      monthly[monthIdx] = {
+        label: `M${monthIdx + 1}`,
+        count: 0,
+        noxSum: 0,
+        teySum: 0,
+        exceed: 0,
+        ratiosNox: [],
+        ratiosCo: [],
+        noxVals: []
+      };
+    }
+
+    const month = monthly[monthIdx];
+    month.count += 1;
+    month.noxSum += row.NOX;
+    month.teySum += row.TEY;
+    month.noxVals.push(row.NOX);
+    if (row.NOX > limit) month.exceed += 1;
+
+    const proxyNox = safeDivide(row.NOX, row.TEY);
+    const proxyCo = safeDivide(row.CO, row.TEY);
+    if (Number.isFinite(proxyNox)) {
+      month.ratiosNox.push(proxyNox);
+      ratioNox.push(proxyNox);
+    }
+    if (Number.isFinite(proxyCo)) {
+      month.ratiosCo.push(proxyCo);
+      ratioCo.push(proxyCo);
+    }
+
+    loadValues.push(row.TEY);
+    noxValues.push(row.NOX);
   });
 
-  chartEfficiency = new Chart(ctxEff, {
-    type: "line",
-    data: { labels, datasets: [{ label: "Efficiency percent", data: eff_pct, tension: 0.25, pointRadius: 0 }] },
-    options: { responsive: true, maintainAspectRatio: false, plugins: { legend: { display: false } }, scales: { y: { min: 35, max: 55 } } }
+  monthly.forEach((month) => {
+    month.avgNox = month.noxSum / month.count;
+    month.p95 = percentile(month.noxVals, 0.95);
+    month.within = 1 - month.exceed / month.count;
+    month.avgProxyNox = average(month.ratiosNox);
+    month.avgProxyCo = average(month.ratiosCo);
+    month.avgLoad = month.teySum / month.count;
   });
 
-  chartCI = new Chart(ctxCI, {
-    type: "line",
-    data: { labels, datasets: [{ label: "gCO₂ per kWh", data: ci_g_per_kwh, tension: 0.25, pointRadius: 0 }] },
-    options: { responsive: true, maintainAspectRatio: false, plugins: { legend: { display: false } } }
+  const overall = {
+    avgNox: average(noxValues),
+    p95: percentile(noxValues, 0.95),
+    within: 1 - countIf(noxValues, (v) => v > limit) / noxValues.length,
+    exceed: countIf(noxValues, (v) => v > limit) / noxValues.length,
+    limit,
+    sampleHours: rows.length
+  };
+
+  const proxyOverall = {
+    avgNoxProxy: average(ratioNox),
+    avgCoProxy: average(ratioCo),
+    avgLoad: average(loadValues)
+  };
+
+  const loadBins = buildLoadBins(rows);
+
+  return { monthly, overall, proxyOverall, loadBins };
+}
+
+function buildLoadBins(rows) {
+  const loads = rows.map((r) => r.TEY).sort((a, b) => a - b);
+  const q1 = percentile(loads, 0.25);
+  const q2 = percentile(loads, 0.5);
+  const q3 = percentile(loads, 0.75);
+
+  const bins = [
+    { label: `≤ ${q1.toFixed(1)} MWh`, min: -Infinity, max: q1 },
+    { label: `${q1.toFixed(1)} – ${q2.toFixed(1)} MWh`, min: q1, max: q2 },
+    { label: `${q2.toFixed(1)} – ${q3.toFixed(1)} MWh`, min: q2, max: q3 },
+    { label: `> ${q3.toFixed(1)} MWh`, min: q3, max: Infinity }
+  ];
+
+  bins.forEach((bin) => {
+    bin.count = 0;
+    bin.avgLoad = 0;
+    bin.avgProxyNox = 0;
+    bin.avgProxyCo = 0;
   });
+
+  rows.forEach((row) => {
+    const proxyNox = safeDivide(row.NOX, row.TEY);
+    const proxyCo = safeDivide(row.CO, row.TEY);
+    const bin = bins.find((b) => row.TEY > b.min && row.TEY <= b.max);
+    if (!bin) return;
+    bin.count += 1;
+    bin.avgLoad += row.TEY;
+    if (Number.isFinite(proxyNox)) bin.avgProxyNox += proxyNox;
+    if (Number.isFinite(proxyCo)) bin.avgProxyCo += proxyCo;
+  });
+
+  bins.forEach((bin) => {
+    if (bin.count === 0) {
+      bin.avgLoad = bin.avgProxyNox = bin.avgProxyCo = 0;
+      return;
+    }
+    bin.avgLoad /= bin.count;
+    bin.avgProxyNox /= bin.count;
+    bin.avgProxyCo /= bin.count;
+  });
+
+  return bins;
+}
+
+// ---------- Rendering helpers ----------
+function updateNoxKpis(overall) {
+  setText("kpi-nox-avg", formatNumber(overall.avgNox, 1));
+  setText("kpi-nox-p95", formatNumber(overall.p95, 1));
+  setText("kpi-nox-within", `${formatNumber(overall.within * 100, 1)}%`);
+  setText("kpi-nox-hours", overall.sampleHours.toLocaleString());
+  const chips = [];
+  chips.push(`${formatNumber((1 - overall.within) * 100, 1)}% exceedances`);
+  chips.push(`Limit: ${formatNumber(overall.limit, 0)} mg/Nm³`);
+  chips.push(`${overall.sampleHours.toLocaleString()} hours analysed`);
+  const tone = overall.within >= 0.95 ? "good" : overall.within >= 0.85 ? "warn" : "bad";
+  setChips("nox-kpi-chips", chips, tone);
+}
+
+function updateProxyKpis(proxy) {
+  setText("kpi-nox-proxy", formatNumber(proxy.avgNoxProxy, 3));
+  setText("kpi-co-proxy", formatNumber(proxy.avgCoProxy, 3));
+  setText("kpi-avg-load", formatNumber(proxy.avgLoad, 1));
+}
+
+function renderMonthlyNoxChart(monthly, limit) {
+  const labels = monthly.map((m) => m.label);
+  const avgNox = monthly.map((m) => m.avgNox);
+  const p95 = monthly.map((m) => m.p95);
+  const withinPct = monthly.map((m) => +(m.within * 100).toFixed(1));
+  const limitLine = monthly.map(() => limit);
+
+  const ctx = document.getElementById("chartNoxMonthly");
+  const data = {
+    labels,
+    datasets: [
+      {
+        type: "line",
+        label: "Avg NOx (mg/Nm³)",
+        data: avgNox,
+        borderColor: "#1d4ed8",
+        tension: 0.25,
+        pointRadius: 0
+      },
+      {
+        type: "line",
+        label: "P95 NOx",
+        data: p95,
+        borderColor: "#9333ea",
+        tension: 0.25,
+        pointRadius: 0
+      },
+      {
+        type: "bar",
+        label: "% within limit",
+        data: withinPct,
+        yAxisID: "y2",
+        backgroundColor: "rgba(16, 185, 129, 0.35)",
+        borderRadius: 6
+      },
+      {
+        type: "line",
+        label: "Limit",
+        data: limitLine,
+        borderColor: "#ef4444",
+        borderDash: [6, 6],
+        pointRadius: 0
+      }
+    ]
+  };
+
+  const options = {
+    responsive: true,
+    maintainAspectRatio: false,
+    scales: {
+      y: {
+        title: { display: true, text: "mg/Nm³" }
+      },
+      y2: {
+        position: "right",
+        beginAtZero: true,
+        max: 100,
+        grid: { drawOnChartArea: false },
+        title: { display: true, text: "% within" }
+      }
+    }
+  };
+
+  if (chartNoxMonthly) {
+    chartNoxMonthly.data = data;
+    chartNoxMonthly.options = options;
+    chartNoxMonthly.update();
+  } else {
+    chartNoxMonthly = new Chart(ctx, { type: "bar", data, options });
+  }
+}
+
+function renderProxyChart(monthly) {
+  const labels = monthly.map((m) => m.label);
+  const noxProxy = monthly.map((m) => m.avgProxyNox);
+  const coProxy = monthly.map((m) => m.avgProxyCo);
+
+  const ctx = document.getElementById("chartProxyMonthly");
+  const data = {
+    labels,
+    datasets: [
+      {
+        label: "NOx / TEY",
+        data: noxProxy,
+        borderColor: "#2563eb",
+        tension: 0.25,
+        pointRadius: 0
+      },
+      {
+        label: "CO / TEY",
+        data: coProxy,
+        borderColor: "#f97316",
+        tension: 0.25,
+        pointRadius: 0
+      }
+    ]
+  };
+
+  const options = {
+    responsive: true,
+    maintainAspectRatio: false,
+    scales: {
+      y: {
+        title: { display: true, text: "mg·Nm⁻³ per MWh" }
+      }
+    }
+  };
+
+  if (chartProxyMonthly) {
+    chartProxyMonthly.data = data;
+    chartProxyMonthly.options = options;
+    chartProxyMonthly.update();
+  } else {
+    chartProxyMonthly = new Chart(ctx, { type: "line", data, options });
+  }
+}
+
+function fillMonthlyTable(monthly) {
+  const tbody = document.getElementById("table-monthly-body");
+  tbody.innerHTML = "";
+  monthly.forEach((m) => {
+    const tr = document.createElement("tr");
+    tr.innerHTML = `
+      <td>${m.label}</td>
+      <td>${formatNumber(m.avgNox, 1)}</td>
+      <td>${formatNumber(m.p95, 1)}</td>
+      <td>${formatNumber(m.within * 100, 1)}%</td>
+      <td>${formatNumber(m.avgProxyNox, 3)}</td>
+      <td>${formatNumber(m.avgProxyCo, 3)}</td>
+      <td>${formatNumber(m.avgLoad, 1)}</td>
+    `;
+    tbody.appendChild(tr);
+  });
+}
+
+function fillLoadBinTable(bins) {
+  const tbody = document.getElementById("table-load-body");
+  tbody.innerHTML = "";
+  bins.forEach((bin) => {
+    const tr = document.createElement("tr");
+    tr.innerHTML = `
+      <td>${bin.label}</td>
+      <td>${bin.count}</td>
+      <td>${formatNumber(bin.avgLoad, 1)}</td>
+      <td>${formatNumber(bin.avgProxyNox, 3)}</td>
+      <td>${formatNumber(bin.avgProxyCo, 3)}</td>
+    `;
+    tbody.appendChild(tr);
+  });
+}
+
+// ---------- Generic helpers ----------
+function safeDivide(num, den) {
+  return den ? num / den : NaN;
+}
+
+function average(arr) {
+  const finite = arr.filter((v) => Number.isFinite(v));
+  if (!finite.length) return 0;
+  const sum = finite.reduce((acc, v) => acc + v, 0);
+  return sum / finite.length;
+}
+
+function percentile(arr, p) {
+  if (!arr.length) return 0;
+  const sorted = [...arr].sort((a, b) => a - b);
+  const idx = (sorted.length - 1) * p;
+  const lower = Math.floor(idx);
+  const upper = Math.ceil(idx);
+  if (lower === upper) return sorted[lower];
+  const weight = idx - lower;
+  return sorted[lower] + weight * (sorted[upper] - sorted[lower]);
+}
+
+function countIf(arr, predicate) {
+  return arr.reduce((acc, value) => acc + (predicate(value) ? 1 : 0), 0);
 }
 
 function setText(id, text) {
   const el = document.getElementById(id);
   if (el) el.textContent = text;
 }
-function setChips(containerId, msgs) {
+
+function setChips(containerId, msgs, tone = "warn") {
   const el = document.getElementById(containerId);
   if (!el) return;
   el.innerHTML = "";
-  msgs.filter(Boolean).forEach(m => {
-    const s = document.createElement("span");
-    s.className = "chip warn";
-    s.textContent = m;
-    el.appendChild(s);
+  msgs.filter(Boolean).forEach((msg) => {
+    const span = document.createElement("span");
+    span.className = `chip ${tone}`;
+    span.textContent = msg;
+    el.appendChild(span);
   });
+}
+
+function formatNumber(value, digits) {
+  return Number.isFinite(value) ? value.toFixed(digits) : "–";
 }

--- a/static/style.css
+++ b/static/style.css
@@ -66,6 +66,9 @@ body{margin:0;font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Aria
 .good{color:var(--good)}.warn{color:var(--warn)}.bad{color:var(--bad)}
 .kpi-chips{display:flex;flex-wrap:wrap;gap:6px}
 .chip{font-size:12px;padding:4px 10px;border-radius:999px;border:1px solid var(--ring);background:#fafafa}
+.chip.good{color:var(--good);background:#ecfdf5;border-color:#bbf7d0}
+.chip.warn{color:var(--warn);background:#fef3c7;border-color:#fde68a}
+.chip.bad{color:var(--bad);background:#fee2e2;border-color:#fecaca}
 
 /* charts area */
 .grid-charts{display:grid;grid-template-columns:2fr 1fr;gap:12px;margin-top:12px}
@@ -76,3 +79,8 @@ body{margin:0;font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Aria
   flex:1;border:1px dashed var(--ring);border-radius:12px;background:#fff;
   display:grid;place-items:center;color:var(--muted)
 }
+.table-wrap{max-height:320px;overflow:auto}
+table{width:100%;border-collapse:collapse;font-size:14px}
+th,td{padding:6px 8px;border-bottom:1px solid var(--ring);text-align:right}
+th:first-child,td:first-child{text-align:left}
+thead th{background:#f3f4f6;font-weight:600}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Gas Turbine Emissions Insights</title>
+    <link rel="stylesheet" href="/static/style.css" />
+  </head>
+  <body style="--hero:url('/static/assets/hero.png')">
+    <header class="site-nav">
+      <div class="nav-inner">
+        <div class="brand"><span class="logo-dot"></span>GT Insights</div>
+        <nav class="nav-links">
+          <a href="/">Home</a>
+          <a href="/dashboard" class="btn-cta">Open dashboard</a>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero">
+        <div class="hero-overlay"></div>
+        <div class="hero-content">
+          <h1 class="hero-title">Operational air emissions made tangible</h1>
+          <p class="hero-sub">Track NOx concentration performance and load-normalised proxy indices from your gas turbine dataset.</p>
+          <div class="hero-actions">
+            <a class="btn-cta" href="/dashboard">Go to dashboard</a>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="container">
+          <h2>What&apos;s inside?</h2>
+          <p class="subhead">Two ready-made analyses using the hourly UCI gas turbine dataset stored in <code>static/data/gt_full.csv</code>.</p>
+          <ul>
+            <li>NOx concentration performance, exceedance rates against a configurable limit, and monthly percentiles.</li>
+            <li>Load-normalised proxy emission indices (NOx/TEY and CO/TEY) trended monthly and segmented by load quartile.</li>
+          </ul>
+          <p class="subhead">Click through to interact with the analyses.</p>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/templates/tabs.html
+++ b/templates/tabs.html
@@ -1,0 +1,137 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Dashboard • Gas Turbine Emissions Insights</title>
+    <link rel="stylesheet" href="/static/style.css" />
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js" defer></script>
+    <script src="/static/app.js" defer></script>
+  </head>
+  <body>
+    <header class="site-nav">
+      <div class="nav-inner">
+        <div class="brand"><span class="logo-dot"></span>GT Insights</div>
+        <nav class="nav-links">
+          <a href="/">Home</a>
+          <a href="/dashboard" class="btn-cta">Dashboard</a>
+        </nav>
+      </div>
+    </header>
+
+    <main class="container section">
+      <h1>Gas turbine emissions dashboard</h1>
+      <p class="subhead">All visuals are computed client-side from <code>static/data/gt_full.csv</code>.</p>
+
+      <div class="tabs">
+        <button class="tab-btn active" data-tab="nox">NOx concentration performance</button>
+        <button class="tab-btn" data-tab="proxy">Load-normalised proxy indices</button>
+      </div>
+
+      <section id="tab-nox" class="tab-panel show">
+        <h2>NOx concentration performance</h2>
+        <p class="subhead">Change the regulatory or internal limit to recalculate exceedance statistics instantly.</p>
+
+        <div class="card" style="margin-bottom:12px;display:flex;flex-wrap:wrap;gap:12px;align-items:center;">
+          <label for="nox-limit">NOx limit (mg/Nm³)</label>
+          <input id="nox-limit" type="number" min="1" step="1" value="70" style="padding:6px 10px;border-radius:8px;border:1px solid var(--ring);width:120px" />
+        </div>
+
+        <div class="grid-kpi">
+          <div class="card">
+            <div class="kpi-label">Average NOx</div>
+            <div class="kpi-value" id="kpi-nox-avg">–</div>
+            <div class="kpi-chips" id="nox-kpi-chips"></div>
+          </div>
+          <div class="card">
+            <div class="kpi-label">P95 NOx</div>
+            <div class="kpi-value" id="kpi-nox-p95">–</div>
+          </div>
+          <div class="card">
+            <div class="kpi-label">Within limit</div>
+            <div class="kpi-value" id="kpi-nox-within">–</div>
+          </div>
+          <div class="card">
+            <div class="kpi-label">Sample hours</div>
+            <div class="kpi-value" id="kpi-nox-hours">–</div>
+            <p class="subhead" style="margin:6px 0 0">Count of valid hourly observations.</p>
+          </div>
+        </div>
+
+        <div class="grid-charts">
+          <div class="card chart">
+            <div class="chart-title">Monthly NOx trend vs limit</div>
+            <div class="chart-box">
+              <canvas id="chartNoxMonthly"></canvas>
+            </div>
+          </div>
+          <div class="card">
+            <div class="chart-title">Monthly summary</div>
+            <div class="table-wrap">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Month</th>
+                    <th>Avg NOx</th>
+                    <th>P95 NOx</th>
+                    <th>% within</th>
+                    <th>NOx/TEY</th>
+                    <th>CO/TEY</th>
+                    <th>Avg TEY</th>
+                  </tr>
+                </thead>
+                <tbody id="table-monthly-body"></tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="tab-proxy" class="tab-panel">
+        <h2>Load-normalised proxy emissions indices</h2>
+        <p class="subhead">Ratios are based on concentration divided by generated electricity (TEY). Use them to understand operational efficiency when stack flow data is unavailable.</p>
+
+        <div class="grid-kpi">
+          <div class="card">
+            <div class="kpi-label">Average NOx / TEY</div>
+            <div class="kpi-value" id="kpi-nox-proxy">–</div>
+          </div>
+          <div class="card">
+            <div class="kpi-label">Average CO / TEY</div>
+            <div class="kpi-value" id="kpi-co-proxy">–</div>
+          </div>
+          <div class="card">
+            <div class="kpi-label">Average load (TEY)</div>
+            <div class="kpi-value" id="kpi-avg-load">–</div>
+          </div>
+        </div>
+
+        <div class="grid-charts">
+          <div class="card chart">
+            <div class="chart-title">Monthly proxy trend</div>
+            <div class="chart-box">
+              <canvas id="chartProxyMonthly"></canvas>
+            </div>
+          </div>
+          <div class="card">
+            <div class="chart-title">Load quartile breakdown</div>
+            <div class="table-wrap">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Load bin</th>
+                    <th>Hours</th>
+                    <th>Avg TEY</th>
+                    <th>Avg NOx/TEY</th>
+                    <th>Avg CO/TEY</th>
+                  </tr>
+                </thead>
+                <tbody id="table-load-body"></tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- replace placeholder dashboard logic with client-side calculations driven by static/data/gt_full.csv
- add NOx concentration and proxy emissions analyses with interactive limit selection, charts, and tables
- introduce landing and dashboard templates plus table styling for clearer presentation

## Testing
- python -m http.server 8000 --bind 0.0.0.0

------
https://chatgpt.com/codex/tasks/task_e_68d84618c328832487600ca00657d5f5