### PR TITLE
Add CO₂ analytics tab and polish dashboard copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
-# sustainability_indicators
-Sustainability indicators for power plants
+# Sustainability indicators dashboard
+
+Flask + Chart.js single-page dashboard exploring gas turbine sustainability insights.
+
+## Features
+
+- Interactive NOx compliance tracking with configurable regulatory limit and monthly statistics.
+- Load-normalised proxy indices (NOx/TEY and CO/TEY) including load quartile segmentation.
+- Synthetic CO₂ ledger summarising tonnes emitted, carbon intensity trend and ETS market exposure.
+
+## Running locally
+
+```bash
+pip install -r requirements.txt  # if dependencies are provided
+flask --app app.py run
+```
+
+Then open <http://127.0.0.1:5000>.

--- a/static/app.js
+++ b/static/app.js
@@ -7,7 +7,8 @@ document.addEventListener("DOMContentLoaded", () => {
   const btns = document.querySelectorAll(".tab-btn");
   const panels = {
     nox: document.getElementById("tab-nox"),
-    proxy: document.getElementById("tab-proxy")
+    proxy: document.getElementById("tab-proxy"),
+    co2: document.getElementById("tab-co2")
   };
 
   btns.forEach((btn) => {
@@ -26,11 +27,24 @@ document.addEventListener("DOMContentLoaded", () => {
 
 // ---------- State ----------
 let rawData = [];
-let chartNoxMonthly, chartProxyMonthly;
+let co2Monthly = [];
+let chartNoxMonthly, chartProxyMonthly, chartCo2Monthly, chartCo2Intensity;
 
 // ---------- Data loading & preparation ----------
 async function initDashboard() {
-  rawData = await loadGTData("/static/data/gt_full.csv");
+  const [gtRows, co2Rows] = await Promise.all([
+    loadCsv("/static/data/gt_full.csv"),
+    loadCsv("/static/data/gt_with_synthetic_co2_monthly.csv")
+  ]);
+
+  rawData = gtRows;
+  co2Monthly = co2Rows.map((row) => ({
+    month: row.month,
+    netMwh: row.net_mwh,
+    co2Tonnes: row.co2_t,
+    avgIntensity: row.avg_intensity_kg_per_mwh,
+    etsCost: row.ets_cost_eur
+  }));
   const limitInput = document.getElementById("nox-limit");
   limitInput.value = DEFAULT_NOX_LIMIT;
   limitInput.addEventListener("change", () => {
@@ -44,7 +58,7 @@ async function initDashboard() {
   renderAll(DEFAULT_NOX_LIMIT);
 }
 
-async function loadGTData(path) {
+async function loadCsv(path) {
   const resp = await fetch(path);
   const text = await resp.text();
   const lines = text.trim().split(/\r?\n/).filter(Boolean);
@@ -54,7 +68,8 @@ async function loadGTData(path) {
     const row = {};
     headers.forEach((h, idx) => {
       if (!h) return;
-      row[h] = Number(values[idx]);
+      const numeric = Number(values[idx]);
+      row[h] = Number.isNaN(numeric) ? values[idx] : numeric;
     });
     return row;
   });
@@ -72,6 +87,7 @@ function renderAll(limit) {
   renderProxyChart(summaries.monthly);
   fillMonthlyTable(summaries.monthly);
   fillLoadBinTable(summaries.loadBins);
+  if (co2Monthly.length) renderCo2(co2Monthly);
 }
 
 function computeSummaries(rows, limit) {
@@ -362,6 +378,169 @@ function fillLoadBinTable(bins) {
   });
 }
 
+function renderCo2(monthly) {
+  if (!monthly.length) return;
+
+  const totals = monthly.reduce(
+    (acc, month) => {
+      acc.netMwh += month.netMwh;
+      acc.co2Tonnes += month.co2Tonnes;
+      acc.etsCost += month.etsCost;
+      acc.weightedIntensity += month.avgIntensity * month.netMwh;
+      return acc;
+    },
+    { netMwh: 0, co2Tonnes: 0, etsCost: 0, weightedIntensity: 0 }
+  );
+
+  const avgIntensity = totals.netMwh ? totals.weightedIntensity / totals.netMwh : 0;
+
+  setText("kpi-co2-mwh", formatNumber(totals.netMwh, 0));
+  setText("kpi-co2-tonnes", formatNumber(totals.co2Tonnes, 0));
+  setText("kpi-co2-intensity", formatNumber(avgIntensity, 1));
+  setText("kpi-co2-ets", formatCurrency(totals.etsCost));
+
+  const peakEmission = monthly.reduce((max, m) => (m.co2Tonnes > max.co2Tonnes ? m : max), monthly[0]);
+  const lowestIntensity = monthly.reduce((min, m) => (m.avgIntensity < min.avgIntensity ? m : min), monthly[0]);
+  const chips = [
+    `Peak month ${peakEmission.month}: ${formatNumber(peakEmission.co2Tonnes, 0)} t`,
+    `Lowest intensity ${lowestIntensity.month}: ${formatNumber(lowestIntensity.avgIntensity, 1)} kg/MWh`
+  ];
+  setChips("co2-kpi-chips", chips, "warn");
+
+  renderCo2EmissionsChart(monthly);
+  renderCo2IntensityChart(monthly);
+  fillCo2Table(monthly);
+}
+
+function renderCo2EmissionsChart(monthly) {
+  const ctx = document.getElementById("chartCo2Monthly");
+  if (!ctx) return;
+
+  const labels = monthly.map((m) => m.month);
+  const co2 = monthly.map((m) => m.co2Tonnes);
+  const cost = monthly.map((m) => m.etsCost);
+
+  const data = {
+    labels,
+    datasets: [
+      {
+        type: "bar",
+        label: "CO₂ (t)",
+        data: co2,
+        backgroundColor: "rgba(59, 130, 246, 0.35)",
+        borderColor: "#3b82f6",
+        borderWidth: 1,
+        borderRadius: 6
+      },
+      {
+        type: "line",
+        label: "ETS cost (€)",
+        data: cost,
+        yAxisID: "y2",
+        borderColor: "#ef4444",
+        tension: 0.25,
+        pointRadius: 0
+      }
+    ]
+  };
+
+  const options = {
+    responsive: true,
+    maintainAspectRatio: false,
+    scales: {
+      y: {
+        beginAtZero: true,
+        title: { display: true, text: "Tonnes" }
+      },
+      y2: {
+        position: "right",
+        beginAtZero: true,
+        grid: { drawOnChartArea: false },
+        title: { display: true, text: "Euro" }
+      }
+    },
+    plugins: {
+      tooltip: {
+        callbacks: {
+          label(context) {
+            if (context.dataset.type === "line") {
+              return `${context.dataset.label}: ${formatCurrency(context.parsed.y)}`;
+            }
+            return `${context.dataset.label}: ${formatNumber(context.parsed.y, 0)} t`;
+          }
+        }
+      }
+    }
+  };
+
+  if (chartCo2Monthly) {
+    chartCo2Monthly.data = data;
+    chartCo2Monthly.options = options;
+    chartCo2Monthly.update();
+  } else {
+    chartCo2Monthly = new Chart(ctx, { type: "bar", data, options });
+  }
+}
+
+function renderCo2IntensityChart(monthly) {
+  const ctx = document.getElementById("chartCo2Intensity");
+  if (!ctx) return;
+
+  const labels = monthly.map((m) => m.month);
+  const intensity = monthly.map((m) => m.avgIntensity);
+
+  const data = {
+    labels,
+    datasets: [
+      {
+        label: "Carbon intensity (kg/MWh)",
+        data: intensity,
+        borderColor: "#10b981",
+        backgroundColor: "rgba(16, 185, 129, 0.25)",
+        tension: 0.25,
+        pointRadius: 0,
+        fill: true
+      }
+    ]
+  };
+
+  const options = {
+    responsive: true,
+    maintainAspectRatio: false,
+    scales: {
+      y: {
+        beginAtZero: false,
+        title: { display: true, text: "kg CO₂ per MWh" }
+      }
+    }
+  };
+
+  if (chartCo2Intensity) {
+    chartCo2Intensity.data = data;
+    chartCo2Intensity.options = options;
+    chartCo2Intensity.update();
+  } else {
+    chartCo2Intensity = new Chart(ctx, { type: "line", data, options });
+  }
+}
+
+function fillCo2Table(monthly) {
+  const tbody = document.getElementById("table-co2-body");
+  if (!tbody) return;
+  tbody.innerHTML = "";
+  monthly.forEach((m) => {
+    const tr = document.createElement("tr");
+    tr.innerHTML = `
+      <td>${m.month}</td>
+      <td>${formatNumber(m.netMwh, 0)}</td>
+      <td>${formatNumber(m.co2Tonnes, 0)}</td>
+      <td>${formatNumber(m.avgIntensity, 1)}</td>
+      <td>${formatCurrency(m.etsCost)}</td>
+    `;
+    tbody.appendChild(tr);
+  });
+}
+
 // ---------- Generic helpers ----------
 function safeDivide(num, den) {
   return den ? num / den : NaN;
@@ -407,5 +586,18 @@ function setChips(containerId, msgs, tone = "warn") {
 }
 
 function formatNumber(value, digits) {
-  return Number.isFinite(value) ? value.toFixed(digits) : "–";
+  return Number.isFinite(value)
+    ? value.toLocaleString(undefined, {
+        minimumFractionDigits: digits,
+        maximumFractionDigits: digits
+      })
+    : "–";
+}
+
+function formatCurrency(value) {
+  return Number.isFinite(value)
+    ? `€${value.toLocaleString(undefined, {
+        maximumFractionDigits: 0
+      })}`
+    : "–";
 }

--- a/static/style.css
+++ b/static/style.css
@@ -73,12 +73,15 @@ body{margin:0;font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Aria
 /* charts area */
 .grid-charts{display:grid;grid-template-columns:2fr 1fr;gap:12px;margin-top:12px}
 @media (max-width:900px){.grid-charts{grid-template-columns:1fr}}
+.grid-charts.two{grid-template-columns:repeat(2,minmax(0,1fr))}
+@media (max-width:900px){.grid-charts.two{grid-template-columns:1fr}}
 .chart{height:320px;display:flex;flex-direction:column}
 .chart-title{font-weight:700;margin-bottom:8px}
 .chart-box{
   flex:1;border:1px dashed var(--ring);border-radius:12px;background:#fff;
   display:grid;place-items:center;color:var(--muted)
 }
+.chart-box canvas{width:100%!important;height:100%!important}
 .table-wrap{max-height:320px;overflow:auto}
 table{width:100%;border-collapse:collapse;font-size:14px}
 th,td{padding:6px 8px;border-bottom:1px solid var(--ring);text-align:right}

--- a/templates/index.html
+++ b/templates/index.html
@@ -21,8 +21,8 @@
       <section class="hero">
         <div class="hero-overlay"></div>
         <div class="hero-content">
-          <h1 class="hero-title">Operational air emissions made tangible</h1>
-          <p class="hero-sub">Track NOx concentration performance and load-normalised proxy indices from your gas turbine dataset.</p>
+          <h1 class="hero-title">Operational emissions made tangible</h1>
+          <p class="hero-sub">Explore NOx compliance, combustion efficiency proxies and a synthetic CO₂ ledger derived from the UCI gas turbine dataset.</p>
           <div class="hero-actions">
             <a class="btn-cta" href="/dashboard">Go to dashboard</a>
           </div>
@@ -32,12 +32,13 @@
       <section class="section">
         <div class="container">
           <h2>What&apos;s inside?</h2>
-          <p class="subhead">Two ready-made analyses using the hourly UCI gas turbine dataset stored in <code>static/data/gt_full.csv</code>.</p>
+          <p class="subhead">Three ready-made analyses powered by <code>static/data/gt_full.csv</code> and the companion CO₂ datasets.</p>
           <ul>
             <li>NOx concentration performance, exceedance rates against a configurable limit, and monthly percentiles.</li>
             <li>Load-normalised proxy emission indices (NOx/TEY and CO/TEY) trended monthly and segmented by load quartile.</li>
+            <li>Carbon ledger summarising tonnes emitted, carbon intensity and ETS exposure using synthetic EUA pricing.</li>
           </ul>
-          <p class="subhead">Click through to interact with the analyses.</p>
+          <p class="subhead">Click through to interact with the dashboard.</p>
         </div>
       </section>
     </main>

--- a/templates/tabs.html
+++ b/templates/tabs.html
@@ -26,6 +26,7 @@
       <div class="tabs">
         <button class="tab-btn active" data-tab="nox">NOx concentration performance</button>
         <button class="tab-btn" data-tab="proxy">Load-normalised proxy indices</button>
+        <button class="tab-btn" data-tab="co2">CO₂ footprint &amp; ETS exposure</button>
       </div>
 
       <section id="tab-nox" class="tab-panel show">
@@ -129,6 +130,64 @@
                 <tbody id="table-load-body"></tbody>
               </table>
             </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="tab-co2" class="tab-panel">
+        <h2>CO₂ footprint &amp; ETS exposure</h2>
+        <p class="subhead">Monthly view derived from <code>static/data/gt_with_synthetic_co2_*.csv</code>. Explore tonnes emitted, carbon intensity and market exposure using the synthetic EUA pricing signal.</p>
+
+        <div class="grid-kpi">
+          <div class="card">
+            <div class="kpi-label">Net generation analysed</div>
+            <div class="kpi-value" id="kpi-co2-mwh">–</div>
+            <div class="kpi-chips" id="co2-kpi-chips"></div>
+          </div>
+          <div class="card">
+            <div class="kpi-label">Total CO₂</div>
+            <div class="kpi-value" id="kpi-co2-tonnes">–</div>
+          </div>
+          <div class="card">
+            <div class="kpi-label">Avg carbon intensity</div>
+            <div class="kpi-value" id="kpi-co2-intensity">–</div>
+          </div>
+          <div class="card">
+            <div class="kpi-label">ETS exposure</div>
+            <div class="kpi-value" id="kpi-co2-ets">–</div>
+          </div>
+        </div>
+
+        <div class="grid-charts two">
+          <div class="card chart">
+            <div class="chart-title">Monthly CO₂ emissions vs ETS cost</div>
+            <div class="chart-box">
+              <canvas id="chartCo2Monthly"></canvas>
+            </div>
+          </div>
+          <div class="card chart">
+            <div class="chart-title">Carbon intensity trend</div>
+            <div class="chart-box">
+              <canvas id="chartCo2Intensity"></canvas>
+            </div>
+          </div>
+        </div>
+
+        <div class="card" style="margin-top:12px">
+          <div class="chart-title">Monthly CO₂ summary</div>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Month</th>
+                  <th>Net MWh</th>
+                  <th>CO₂ (t)</th>
+                  <th>Intensity (kg/MWh)</th>
+                  <th>ETS cost (€)</th>
+                </tr>
+              </thead>
+              <tbody id="table-co2-body"></tbody>
+            </table>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- load the synthetic CO₂ datasets alongside the turbine telemetry and compute carbon ledger insights
- add a dedicated CO₂ footprint tab with KPIs, dual-axis charting, and monthly summary table plus responsive styling updates
- refresh landing page copy and README to describe the expanded dashboard

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d8d7799ca08324bb0601acfd991e6c