### PR TITLE
Fix Regulatory Readiness tab display

### DIFF
--- a/app.py
+++ b/app.py
@@ -27,7 +27,7 @@ def dashboard():
         'data_quality': 0,
         'reporting_gaps': 0
     }
-    return render_template("tabs.html", active_tab="emissions", reg_compliance=reg_compliance)
+    return render_template("tabs.html", active_tab="nox", reg_compliance=reg_compliance)
 
 def calculate_regulatory_readiness_score(form_data):
     """Calculate regulatory readiness score based on form data.

--- a/static/app.js
+++ b/static/app.js
@@ -8,7 +8,8 @@ document.addEventListener("DOMContentLoaded", () => {
   const panels = {
     nox: document.getElementById("tab-nox"),
     proxy: document.getElementById("tab-proxy"),
-    co2: document.getElementById("tab-co2")
+    co2: document.getElementById("tab-co2"),
+    regulationscore: document.getElementById("tab-regulationscore")
   };
 
   btns.forEach((btn) => {
@@ -16,9 +17,11 @@ document.addEventListener("DOMContentLoaded", () => {
     btn.addEventListener("click", () => {
       btns.forEach((b) => b.classList.remove("active"));
       btn.classList.add("active");
-      Object.values(panels).forEach((panel) => panel.classList.remove("show"));
-      panels[btn.dataset.tab].classList.add("show");
-      panels[btn.dataset.tab].scrollIntoView({ behavior: "smooth", block: "start" });
+      Object.values(panels).forEach((panel) => panel && panel.classList.remove("show"));
+      const panel = panels[btn.dataset.tab];
+      if (!panel) return;
+      panel.classList.add("show");
+      panel.scrollIntoView({ behavior: "smooth", block: "start" });
     });
   });
 

--- a/templates/tabs.html
+++ b/templates/tabs.html
@@ -25,13 +25,13 @@
       
 
       <div class="tabs">
-        <button class="tab-btn active" data-tab="nox">NOx concentration performance</button>
-        <button class="tab-btn" data-tab="proxy">Load-normalised proxy indices</button>
-        <button class="tab-btn" data-tab="co2">CO₂ footprint &amp; ETS exposure</button>
-        <button class="tab-btn" data-tab="regulationscore">Regulatory Readiness Score</button>
+        <button class="tab-btn {% if active_tab == 'nox' %}active{% endif %}" data-tab="nox">NOx concentration performance</button>
+        <button class="tab-btn {% if active_tab == 'proxy' %}active{% endif %}" data-tab="proxy">Load-normalised proxy indices</button>
+        <button class="tab-btn {% if active_tab == 'co2' %}active{% endif %}" data-tab="co2">CO₂ footprint &amp; ETS exposure</button>
+        <button class="tab-btn {% if active_tab == 'regulationscore' %}active{% endif %}" data-tab="regulationscore">Regulatory Readiness Score</button>
       </div>
 
-      <section id="tab-nox" class="tab-panel show">
+      <section id="tab-nox" class="tab-panel {% if active_tab == 'nox' %}show{% endif %}">
         <h2>NOx concentration performance</h2>
         <p class="subhead">Change the regulatory or internal limit to recalculate exceedance statistics instantly.</p>
 
@@ -90,7 +90,7 @@
         </div>
       </section>
 
-      <section id="tab-proxy" class="tab-panel">
+      <section id="tab-proxy" class="tab-panel {% if active_tab == 'proxy' %}show{% endif %}">
         <h2>Load-normalised proxy emissions indices</h2>
         <p class="subhead">Ratios are based on concentration divided by generated electricity (TEY). Use them to understand operational efficiency when stack flow data is unavailable.</p>
 
@@ -136,7 +136,7 @@
         </div>
       </section>
 
-      <section id="tab-co2" class="tab-panel">
+      <section id="tab-co2" class="tab-panel {% if active_tab == 'co2' %}show{% endif %}">
         <h2>CO₂ footprint &amp; ETS exposure</h2>
         <p class="subhead">Monthly view derived from <code>static/data/gt_with_synthetic_co2_*.csv</code>. Explore tonnes emitted, carbon intensity and market exposure using the synthetic EUA pricing signal.</p>
 
@@ -194,7 +194,7 @@
         </div>
       </section>
       <!--Regulation Score tab-->
-  <section class="tab-panel {% if active_tab == 'regulationscore' %}show{% endif %}" id="tab-regulationscore" role="region" aria-labelledby="tabbtn-efficiency">
+  <section class="tab-panel {% if active_tab == 'regulationscore' %}show{% endif %}" id="tab-regulationscore" role="region" aria-labelledby="tabbtn-regulationscore">
     <div class="score-container">
       <div class="score-header">Regulatory Readiness Score</div>
       <div class="score-bar">


### PR DESCRIPTION
## Summary
- highlight the requested tab server-side so the Regulatory Readiness panel renders when active
- include the Regulatory Readiness panel in the front-end tab switching logic to avoid missing content
- default the dashboard to the NOx tab on load for GET requests

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d8e7f22f84832498f123bdb7c2c47d