### PR TITLE
Add tab metric descriptions and expand README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,70 @@
-# Sustainability indicators dashboard
+# Sustainability Indicators Dashboard
 
-Flask + Chart.js single-page dashboard exploring gas turbine sustainability insights.
+A Flask web dashboard that combines gas turbine emissions analytics, carbon exposure estimates, and regulatory readiness tracking. The UI is built with vanilla HTML/CSS and Chart.js to keep dependencies light while still offering interactive data visualisations.
 
-## Features
+## Key capabilities
 
-- Interactive NOx compliance tracking with configurable regulatory limit and monthly statistics.
-- Load-normalised proxy indices (NOx/TEY and CO/TEY) including load quartile segmentation.
-- Synthetic CO₂ ledger summarising tonnes emitted, carbon intensity trend and ETS market exposure.
+- **NOx concentration performance** – Analyse hourly nitrogen oxides data against configurable compliance limits with P95 exceedance insights, monthly summaries, and limit-sensitive callouts.
+- **Load-normalised proxy indices** – Track NOx/TEY and CO/TEY ratios when stack flow data is unavailable, including quartile analysis by turbine loading.
+- **CO₂ footprint & ETS exposure** – Combine synthetic EUA pricing, tonnes emitted, and carbon intensity trends to estimate carbon market obligations.
+- **Regulatory readiness score** – Capture qualitative compliance signals across EU ETS, CSRD, EED, US EPA GHG reporting, data quality, and outstanding actions.
 
-## Running locally
+## Project structure
 
-```bash
-pip install -r requirements.txt  # if dependencies are provided
-flask --app app.py run
+```
+.
+├── app.py                # Flask routes, data loading, and tab selection logic
+├── static/
+│   ├── app.js            # Fetches CSVs, renders charts, updates KPIs
+│   ├── style.css         # Shared styles for layout, cards, charts, typography
+│   └── regulatory.css    # Additional styling for the readiness score section
+├── templates/
+│   ├── index.html        # Marketing-style landing page
+│   └── tabs.html         # Dashboard view with the four analytical tabs
+└── static/data/          # CSV inputs for NOx, proxy, and synthetic CO₂ datasets
 ```
 
-Then open <http://127.0.0.1:5000>.
+## Data inputs
+
+The dashboard reads pre-generated CSV files bundled in `static/data/`:
+
+- `gt_nox.csv` – Hourly NOx concentration measurements with TEY load context.
+- `gt_proxy.csv` – Aggregated load quartile metrics for NOx/TEY and CO/TEY ratios.
+- `gt_with_synthetic_co2_*.csv` – Synthetic carbon ledger with ETS price traces.
+
+Update or replace these files to refresh the analysis; the frontend reloads data automatically on page visit.
+
+## Getting started
+
+1. **Create a virtual environment (optional but recommended):**
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   ```
+2. **Install dependencies:**
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. **Run the development server:**
+   ```bash
+   flask --app app.py run --debug
+   ```
+4. Open <http://127.0.0.1:5000> to view the dashboard.
+
+The Flask app only serves static data, so no database setup is required. Use the `--debug` flag during development for hot reloading and detailed error output.
+
+## Development tips
+
+- **Static assets:** Update `static/app.js` for data wrangling and chart behaviour. Update `static/style.css` or `static/regulatory.css` for styling tweaks.
+- **Templates:** Modify `templates/tabs.html` to adjust layout or copy for each analytics tab. The `active_tab` context variable controls which tab appears on load.
+- **Testing data changes:** Because the frontend loads CSV files directly, you can iterate quickly by editing the CSVs and refreshing the browser.
+
+## Deployment considerations
+
+- Configure `FLASK_ENV=production` and run behind a production-grade WSGI server (Gunicorn, uWSGI) for live environments.
+- Serve the app behind TLS and apply authentication if sensitive operational data is exposed.
+- Replace the synthetic datasets with live telemetry or data warehouse extracts, ensuring CSV schemas match expectations in `static/app.js`.
+
+## License
+
+This project is provided for demonstration purposes. Adapt licensing as required for your organisation.

--- a/static/style.css
+++ b/static/style.css
@@ -63,6 +63,7 @@ body{margin:0;font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Aria
 }
 .kpi-label{color:var(--muted);font-size:14px;margin-bottom:6px}
 .kpi-value{font-size:clamp(22px,3vw,30px);font-weight:800}
+.kpi-desc{margin:8px 0 0;color:var(--muted);font-size:13px;line-height:1.35;clear:both}
 .good{color:var(--good)}.warn{color:var(--warn)}.bad{color:var(--bad)}
 .kpi-chips{display:flex;flex-wrap:wrap;gap:6px}
 .chip{font-size:12px;padding:4px 10px;border-radius:999px;border:1px solid var(--ring);background:#fafafa}

--- a/templates/tabs.html
+++ b/templates/tabs.html
@@ -44,32 +44,37 @@
           <div class="card">
             <div class="kpi-label">Average NOx</div>
             <div class="kpi-value" id="kpi-nox-avg">–</div>
+            <p class="kpi-desc">Mean hourly NOx concentration compared with the active limit.</p>
             <div class="kpi-chips" id="nox-kpi-chips"></div>
           </div>
           <div class="card">
             <div class="kpi-label">P95 NOx</div>
             <div class="kpi-value" id="kpi-nox-p95">–</div>
+            <p class="kpi-desc">95th percentile NOx level showing the upper compliance boundary.</p>
           </div>
           <div class="card">
             <div class="kpi-label">Within limit</div>
             <div class="kpi-value" id="kpi-nox-within">–</div>
+            <p class="kpi-desc">Share of monitored hours that stayed below the chosen threshold.</p>
           </div>
           <div class="card">
             <div class="kpi-label">Sample hours</div>
             <div class="kpi-value" id="kpi-nox-hours">–</div>
-            <p class="subhead" style="margin:6px 0 0">Count of valid hourly observations.</p>
+            <p class="kpi-desc">Count of valid hourly observations feeding the statistics.</p>
           </div>
         </div>
 
         <div class="grid-charts">
           <div class="card chart">
             <div class="chart-title">Monthly NOx trend vs limit</div>
+            <p class="kpi-desc">Tracks rolling monthly averages against the configurable regulatory cap.</p>
             <div class="chart-box">
               <canvas id="chartNoxMonthly"></canvas>
             </div>
           </div>
           <div class="card">
             <div class="chart-title">Monthly summary</div>
+            <p class="kpi-desc">Tabular breakdown of concentration metrics and proxy ratios by month.</p>
             <div class="table-wrap">
               <table>
                 <thead>
@@ -98,26 +103,31 @@
           <div class="card">
             <div class="kpi-label">Average NOx / TEY</div>
             <div class="kpi-value" id="kpi-nox-proxy">–</div>
+            <p class="kpi-desc">Average nitrogen oxides per unit of turbine equivalent load.</p>
           </div>
           <div class="card">
             <div class="kpi-label">Average CO / TEY</div>
             <div class="kpi-value" id="kpi-co-proxy">–</div>
+            <p class="kpi-desc">Carbon monoxide intensity normalised by generated electricity.</p>
           </div>
           <div class="card">
             <div class="kpi-label">Average load (TEY)</div>
             <div class="kpi-value" id="kpi-avg-load">–</div>
+            <p class="kpi-desc">Typical turbine load observed across the analysed period.</p>
           </div>
         </div>
 
         <div class="grid-charts">
           <div class="card chart">
             <div class="chart-title">Monthly proxy trend</div>
+            <p class="kpi-desc">Shows how normalised NOx and CO ratios evolve versus turbine output.</p>
             <div class="chart-box">
               <canvas id="chartProxyMonthly"></canvas>
             </div>
           </div>
           <div class="card">
             <div class="chart-title">Load quartile breakdown</div>
+            <p class="kpi-desc">Compares intensity metrics across operating load segments.</p>
             <div class="table-wrap">
               <table>
                 <thead>
@@ -144,31 +154,37 @@
           <div class="card">
             <div class="kpi-label">Net generation analysed</div>
             <div class="kpi-value" id="kpi-co2-mwh">–</div>
+            <p class="kpi-desc">Total electricity (MWh) covered by the emissions ledger.</p>
             <div class="kpi-chips" id="co2-kpi-chips"></div>
           </div>
           <div class="card">
             <div class="kpi-label">Total CO₂</div>
             <div class="kpi-value" id="kpi-co2-tonnes">–</div>
+            <p class="kpi-desc">Aggregated tonnes of carbon dioxide emitted in the timeframe.</p>
           </div>
           <div class="card">
             <div class="kpi-label">Avg carbon intensity</div>
             <div class="kpi-value" id="kpi-co2-intensity">–</div>
+            <p class="kpi-desc">Weighted average emissions per MWh produced.</p>
           </div>
           <div class="card">
             <div class="kpi-label">ETS exposure</div>
             <div class="kpi-value" id="kpi-co2-ets">–</div>
+            <p class="kpi-desc">Indicative market cost using the synthetic EUA pricing signal.</p>
           </div>
         </div>
 
         <div class="grid-charts two">
           <div class="card chart">
             <div class="chart-title">Monthly CO₂ emissions vs ETS cost</div>
+            <p class="kpi-desc">Contrasts tonnes emitted with the associated ETS liability each month.</p>
             <div class="chart-box">
               <canvas id="chartCo2Monthly"></canvas>
             </div>
           </div>
           <div class="card chart">
             <div class="chart-title">Carbon intensity trend</div>
+            <p class="kpi-desc">Highlights efficiency improvements or regressions over time.</p>
             <div class="chart-box">
               <canvas id="chartCo2Intensity"></canvas>
             </div>
@@ -177,6 +193,7 @@
 
         <div class="card" style="margin-top:12px">
           <div class="chart-title">Monthly CO₂ summary</div>
+          <p class="kpi-desc">Monthly ledger of production, emissions, intensity and ETS exposure.</p>
           <div class="table-wrap">
             <table>
               <thead>
@@ -197,18 +214,31 @@
   <section class="tab-panel {% if active_tab == 'regulationscore' %}show{% endif %}" id="tab-regulationscore" role="region" aria-labelledby="tabbtn-regulationscore">
     <div class="score-container">
       <div class="score-header">Regulatory Readiness Score</div>
+      <p class="subhead">Weighted view of how well the plant meets major compliance frameworks and reporting duties.</p>
       <div class="score-bar">
         <div class="score-fill" id="scoreFill" style="width: {{ reg_compliance.score or 0 }}%;">{{ reg_compliance.score or 0 }} /
           100</div>
       </div>
 
       <div class="score-breakdown">
-        <div class="score-item">EU ETS Compliance <span>{{ reg_compliance.ets or 0 }}%</span></div>
-        <div class="score-item">CSRD Alignment <span>{{ reg_compliance.csrd or 0 }}%</span></div>
-        <div class="score-item">EED Compliance <span>{{ reg_compliance.eed or 0 }}%</span></div>
-        <div class="score-item">US EPA GHG Reporting <span>{{ reg_compliance.epa_ghg or 0 }}%</span></div>
-        <div class="score-item">Data Quality & Traceability <span>{{ reg_compliance.data_quality or 0 }}%</span></div>
-        <div class="score-item">Deadlines & Gaps <span>{{ reg_compliance.reporting_gaps or 0 }}%</span></div>
+        <div class="score-item">EU ETS Compliance <span>{{ reg_compliance.ets or 0 }}%</span>
+          <p class="kpi-desc">Allowance management and verified reporting status.</p>
+        </div>
+        <div class="score-item">CSRD Alignment <span>{{ reg_compliance.csrd or 0 }}%</span>
+          <p class="kpi-desc">Progress against sustainability disclosure requirements.</p>
+        </div>
+        <div class="score-item">EED Compliance <span>{{ reg_compliance.eed or 0 }}%</span>
+          <p class="kpi-desc">Energy efficiency audits and improvement plans.</p>
+        </div>
+        <div class="score-item">US EPA GHG Reporting <span>{{ reg_compliance.epa_ghg or 0 }}%</span>
+          <p class="kpi-desc">Status of US greenhouse gas registration and submissions.</p>
+        </div>
+        <div class="score-item">Data Quality & Traceability <span>{{ reg_compliance.data_quality or 0 }}%</span>
+          <p class="kpi-desc">Confidence in measurement calibration and audit trails.</p>
+        </div>
+        <div class="score-item">Deadlines & Gaps <span>{{ reg_compliance.reporting_gaps or 0 }}%</span>
+          <p class="kpi-desc">Outstanding actions or overdue regulatory deliverables.</p>
+        </div>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- add concise explanations for KPIs and visualisations across the dashboard tabs
- refresh regulatory readiness messaging with contextual descriptions for each metric
- rewrite the README with detailed setup, data and project structure guidance

## Testing
- not run (Flask dependencies unavailable in execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68d8ead5eeec8324ac1316464cd7132d